### PR TITLE
Added max window size for altitude graph during prelaunch phase

### DIFF
--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -66,6 +66,14 @@ def updateAltitude():
         altitudeData = np.extract(timeBeforeLaunch, altitudeData)
         altitudeTime = np.extract(timeBeforeLaunch, altitudeTime)
 
+    elif len(altitudeData):
+        #before launch, maintain the last 10 seconds of altitude data on the graph
+
+        timeWindow = altitudeTime > altitudeTime[-1] - timedelta(seconds=10)
+
+        altitudeData = np.extract(timeWindow, altitudeData)
+        altitudeTime = np.extract(timeWindow, altitudeTime)
+
     if(cache.flightState["last"] == "LANDED" and cache.altitudeCache["time"][-1].timestamp() * 1000 >= (cache.flightState["LANDED"].timestamp() * 1000 + 5000)):
         #check to see if the time on the data is 5 seconds after the landing
 


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
<!-- Clearly describe the problem you're solving-->
- The previous implementation would display the all of our altitude data before launch. That meant that if the rocket sat on the pad for 5 minutes the graph would be inundated with datapoints and effectively useless. Upon launch the graph would instantly reduce to a normal window size with a very jerky transition.

## Solution
<!-- Describe your thought process and the steps you took to find a solution. If your process resulted in a new issue being created, link it here-->
- Capped out the window size at 10 seconds
  - this makes it very easy to see data coming in. It also results in a smooth transition once launch occurs since the 10 seconds of data preceding the launch will be kept on the display.

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. ran a unit test, verified behavior with real data etc.)-->
<!-- ex:
- Verified functionality using "test" mode
-->
- Verified new display using "test" mode
- demonstrated use of display during a launch in @Serenasidlow 's Scorpion on `5/7/23`