### PR TITLE
Completed name change to Synergist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Catalyst-UI
+# Synergist
 A graphical interface for sounding rocket telemetry
 
 ## Quickstart
 1. Download and Install the latest version of [Python](https://www.python.org/downloads/)
 1. Clone this repository
 1. Run the following commands:
-    1. `cd Catalyst-UI`
+    1. `cd Synergist`
     1. `pip3 install virtualenv`
     1. `python3 -m venv venv`
     1. `source venv/bin/activate`

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -12,7 +12,7 @@ app = dash.Dash()
 #arrangment of dashboard using HTML
 app.layout = html.Div(
     [
-        html.H2('Catalyst-2', style={'color':"#aaaaaa"}),
+        html.H2('Synergist', style={'color':"#aaaaaa"}),
         html.Div([
             dcc.Graph(id="altitude", figure=go.FigureWidget()),
         ], style={"width": "65%", "height": "50%", "display": "inline-block"}),


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
This software was originally called Catalyst-UI, which lead to some confusion as to what "Catalyst" actually referred to. Additionally, Catalyst-2 is no longer the only flight computer that uses this UI.

## Solution
Changed name to one that thematically goes with Catalyst, `Synergist`, while making it clear that this software is distinct from both the Catalyst-2 flight computer hardware and the Stimulant flight software.

The repository name has already been updated.